### PR TITLE
Error yaml file

### DIFF
--- a/lib/stacker/cli.rb
+++ b/lib/stacker/cli.rb
@@ -151,7 +151,12 @@ YAML
       @region ||= begin
         config_path =  File.join working_path, 'regions', "#{options['region']}.yml"
         if File.exists? config_path
-          config = YAML.load_file(config_path)
+          begin
+            config = YAML.load_file(config_path)
+          rescue Psych::SyntaxError => err
+            Stacker.logger.fatal err.message
+            exit 1
+          end
 
           defaults = config.fetch 'defaults', {}
           stacks = config.fetch 'stacks', {}

--- a/lib/stacker/region.rb
+++ b/lib/stacker/region.rb
@@ -10,7 +10,12 @@ module Stacker
       @name = name
       @defaults = defaults
       @stacks = stacks.map do |options|
-        Stack.new self, options.fetch('name'), options
+        begin
+          Stack.new self, options.fetch('name'), options
+        rescue KeyError => err
+         Stacker.logger.fatal "Malformed YAML: #{err.message}"
+         exit 1
+        end
       end
       @templates_path = templates_path
     end


### PR DESCRIPTION
Branched off of `error-config-file` to avoid merge conflicts, might want to merge `error-config-file` first.

Fixes #4
