### PR TITLE
Show template syntax errors when json parse fails

### DIFF
--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -3,18 +3,13 @@ require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/module/delegation'
 require 'aws-sdk'
 require 'memoist'
+require 'stacker/stack/errors'
 require 'stacker/stack/capabilities'
 require 'stacker/stack/parameters'
 require 'stacker/stack/template'
 
 module Stacker
   class Stack
-
-    class Error < StandardError; end
-    class StackPolicyError < Error; end
-    class DoesNotExistError < Error; end
-    class MissingParameters < Error; end
-    class UpToDateError < Error; end
 
     extend Memoist
 

--- a/lib/stacker/stack/errors.rb
+++ b/lib/stacker/stack/errors.rb
@@ -1,0 +1,41 @@
+require 'jsonlint'
+
+module Stacker
+  class Stack
+
+    class Error < StandardError; end
+    class StackPolicyError < Error; end
+    class DoesNotExistError < Error; end
+    class MissingParameters < Error; end
+    class UpToDateError < Error; end
+
+    class TemplateSyntaxError < Error
+
+      def initialize(path)
+        @path = path
+      end
+
+      def message
+        <<END_MSG
+Syntax error(s) in template.
+#{path}:
+#{errors}
+END_MSG
+      end
+
+      private
+
+      attr_reader :path
+
+      def errors
+        @errors ||= begin
+          linter = JsonLint::Linter.new
+          linter.check path
+          linter.errors.values.join "\n"
+        end
+      end
+
+    end
+
+  end
+end

--- a/lib/stacker/stack/template.rb
+++ b/lib/stacker/stack/template.rb
@@ -2,6 +2,7 @@ require 'active_support/core_ext/string/inflections'
 require 'json'
 require 'memoist'
 require 'stacker/differ'
+require 'stacker/stack'
 require 'stacker/stack/component'
 
 module Stacker
@@ -26,6 +27,8 @@ module Stacker
             {}
           end
         end
+      rescue JSON::ParserError
+        raise TemplateSyntaxError.new path
       end
 
       def remote

--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coderay', '~> 1.1'
   s.add_dependency 'diffy', '~> 3.0'
   s.add_dependency 'indentation', '~> 0.0'
+  s.add_dependency 'jsonlint', '~> 0.2.0'
   s.add_dependency 'memoist', '~> 0.14'
   s.add_dependency 'rainbow', '~> 1.1'
   s.add_dependency 'thor', '~> 0.18'


### PR DESCRIPTION
```bash
$ be stacker diff VPC
VPC:
Syntax error(s) in template.
/Users/jfhamlin/Projects/teststacks/templates/VPC.json:
expected hash key, not a hash close at line 15, column 9 [parse.c:556]
```