### PR TITLE
Upgrade AWS SDK to 2.6 and lay groundwork for stack changesets.

### DIFF
--- a/lib/stacker/cli.rb
+++ b/lib/stacker/cli.rb
@@ -50,6 +50,8 @@ module Stacker
       with_one_or_all(stack_name) do |stack|
         Stacker.logger.debug stack.status.indent
       end
+    rescue Aws::CloudFormation::Errors::ValidationError => err
+      Stacker.logger.fatal err.to_s
     end
 
     desc "diff [STACK_NAME]", "Show outstanding stack differences"
@@ -162,6 +164,7 @@ YAML
       Stacker.logger.info "\n#{templ_diff.indent}\n" if templ_diff.length > 0
       Stacker.logger.info "\n#{param_diff.indent}\n" if param_diff.length > 0
 
+      Stacker.logger.info stack.pretty_change_set
       true
     end
 

--- a/lib/stacker/logging.rb
+++ b/lib/stacker/logging.rb
@@ -1,6 +1,7 @@
 require 'coderay'
 require 'delegate'
 require 'indentation'
+require 'logger'
 require 'rainbow'
 
 module Stacker

--- a/lib/stacker/region.rb
+++ b/lib/stacker/region.rb
@@ -1,5 +1,6 @@
 require 'aws-sdk'
 require 'stacker/stack'
+require 'stacker/stack/errors'
 
 module Stacker
   class Region
@@ -21,11 +22,13 @@ module Stacker
     end
 
     def client
-      @client ||= AWS::CloudFormation.new region: name
+      @client ||= Aws::CloudFormation::Client.new region: name
     end
 
     def stack name
-      stacks.find { |s| s.name == name } || Stack.new(self, name)
+      stacks.find { |s| s.name == name }.tap do |stk|
+        raise Stack::StackUndeclared.new name unless stk
+      end
     end
 
   end

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -3,6 +3,8 @@ require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/module/delegation'
 require 'aws-sdk'
 require 'memoist'
+require 'securerandom'
+
 require 'stacker/stack/errors'
 require 'stacker/stack/capabilities'
 require 'stacker/stack/parameters'
@@ -16,9 +18,7 @@ module Stacker
     CLIENT_METHODS = %w[
       creation_time
       description
-      exists?
       last_updated_time
-      status
       status_reason
     ]
 
@@ -41,6 +41,8 @@ module Stacker
 }
 JSON
 
+    STATUS_COMPLETE_REGEX = /(ROLLBACK|CREATE|UPDATE)_(COMPLETE|FAILED)/
+
     attr_reader :region, :name, :options
 
     def initialize region, name, options = {}
@@ -48,7 +50,22 @@ JSON
     end
 
     def client
-      @client ||= region.client.stacks[name]
+      res = region.client.describe_stacks(stack_name: name)
+      res.stacks.first
+    rescue Aws::CloudFormation::Errors::ValidationError
+      nil
+    end
+
+    def exists?
+      !!client
+    end
+
+    def status
+      if client
+        client.stack_status
+      else
+        "#{name}:\nStack with id #{name} does not exist"
+      end
     end
 
     delegate *CLIENT_METHODS, to: :client
@@ -73,7 +90,9 @@ JSON
     def outputs
       @outputs ||= begin
         return {} unless complete?
-        Hash[client.outputs.map { |output| [ output.key, output.value ] }]
+        Hash[client.outputs.map do |output|
+               [ output.output_key, output.output_value ]
+             end]
       end
     end
 
@@ -91,15 +110,22 @@ JSON
 
       Stacker.logger.info 'Creating stack'
 
-      region.client.stacks.create(
-        name,
-        template.local,
-        parameters: parameters.resolved,
+      params = parameters.resolved.map do |k, v|
+        {
+          parameter_key: k,
+          parameter_value: v
+        }
+      end
+
+      region.client.create_stack(
+        stack_name: name,
+        template_body: template.local.to_json,
+        parameters: params,
         capabilities: capabilities.local
       )
 
-      wait_while_status 'CREATE_IN_PROGRESS' if blocking
-    rescue AWS::CloudFormation::Errors::ValidationError => err
+      wait_until_complete if blocking
+    rescue Aws::CloudFormation::Errors::ValidationError => err
       raise Error.new err.message
     end
 
@@ -117,20 +143,23 @@ JSON
 
       Stacker.logger.info 'Updating stack'
 
-      update_params = {
-        template: template.local,
-        parameters: parameters.resolved,
-        capabilities: capabilities.local
-      }
-
       unless allow_destructive
-        update_params[:stack_policy_during_update_body] = SAFE_UPDATE_POLICY
+        raise StackPolicyError if describe_change_set.any? do |c|
+          c[:change][:replacement] == 'True' ||
+            c[:change][:action] =~ /remove/i
+        end
       end
 
-      client.update(update_params)
+      region.client.execute_change_set(
+        change_set_name: change_set,
+        stack_name: name
+      )
 
-      wait_while_status 'UPDATE_IN_PROGRESS' if blocking
-    rescue AWS::CloudFormation::Errors::ValidationError => err
+      if blocking
+        sleep 4 # Wait a bit for the stack to begin updating
+        wait_until_complete
+      end
+    rescue Aws::CloudFormation::Errors::ValidationError => err
       case err.message
       when /does not exist/
         raise DoesNotExistError.new err.message
@@ -141,7 +170,76 @@ JSON
       end
     end
 
+    def describe_change_set
+      retries = 6
+      changes = []
+      while changes.empty?
+        resp = region.client.describe_change_set(
+          change_set_name: change_set,
+          stack_name: name
+        )
+        changes = resp.changes
+        if changes.empty?
+          raise CannotDescribeChangeSet.new 'Empty change set' if retries == 0
+          retries -= 1
+          sleep 1
+        end
+      end
+      changes.map do |c|
+        rc = c.resource_change
+        {
+          type: c.type,
+          change: {
+            logical_resource_id: rc.logical_resource_id,
+            action: rc.action,
+            replacement: rc.replacement,
+          }
+        }
+      end
+    end
+    memoize :describe_change_set
+
+    def pretty_change_set
+      riw = describe_change_set.map do |c|
+        c[:change][:logical_resource_id].length
+      end.max
+      fmt = "%-6s %-#{riw}s %-5s"
+
+      ([fmt % ['Action', 'Resource', 'Replacement?'], '='*(riw+20)] +
+        describe_change_set.map do |c|
+        change = c[:change]
+        fmt % [
+          change[:action],
+          change[:logical_resource_id],
+          change[:replacement]
+        ]
+      end).join("\n")
+    end
+
     private
+
+    def change_set_name
+      "stacker-#{SecureRandom.hex}"
+    end
+    memoize :change_set_name
+
+    def change_set
+      change_set_name.tap do |csname|
+        region.client.create_change_set(
+          stack_name: name,
+          template_body: template.local.to_json,
+          parameters: parameters.resolved.map do |k, v|
+            {
+              parameter_key: k,
+              parameter_value: v
+            }
+          end,
+          capabilities: capabilities.local,
+          change_set_name: csname
+        )
+      end
+    end
+    memoize :change_set
 
     def report_status
       case status
@@ -163,8 +261,8 @@ JSON
       end
     end
 
-    def wait_while_status wait_status
-      while flush_cache('status') && status == wait_status
+    def wait_until_complete
+      while !(status =~ STATUS_COMPLETE_REGEX)
         report_status
         sleep 5
       end
@@ -173,4 +271,3 @@ JSON
 
   end
 end
-

--- a/lib/stacker/stack/capabilities.rb
+++ b/lib/stacker/stack/capabilities.rb
@@ -9,7 +9,9 @@ module Stacker
       end
 
       def remote
-        @remote ||= client.capabilities
+        # `capabilities` actually returns a
+        # !ruby/array:Aws::Xml::DefaultList
+        @remote ||= client.capabilities.to_a
       end
 
     end

--- a/lib/stacker/stack/errors.rb
+++ b/lib/stacker/stack/errors.rb
@@ -8,6 +8,19 @@ module Stacker
     class DoesNotExistError < Error; end
     class MissingParameters < Error; end
     class UpToDateError < Error; end
+    class CannotDescribeChangeSet < Error; end
+
+    class StackUndeclared < Error
+
+      def initialize(name)
+        @name = name
+      end
+
+      def message
+        "Stack with id #{@name} is not declared"
+      end
+
+    end
 
     class TemplateSyntaxError < Error
 

--- a/lib/stacker/stack/parameters.rb
+++ b/lib/stacker/stack/parameters.rb
@@ -44,7 +44,9 @@ module Stacker
       end
 
       def remote
-        client.parameters
+        Hash[client.parameters.map do |p|
+               [p.parameter_key, p.parameter_value]
+             end]
       end
       memoize :remote
 

--- a/lib/stacker/stack/template.rb
+++ b/lib/stacker/stack/template.rb
@@ -32,8 +32,9 @@ module Stacker
       end
 
       def remote
-        @remote ||= JSON.parse client.template
-      rescue AWS::CloudFormation::Errors::ValidationError => err
+        @remote ||= JSON.parse stack.region.client.get_template(
+                                 stack_name: stack.name).template_body
+      rescue Aws::CloudFormation::Errors::ValidationError => err
         if err.message =~ /does not exist/
           raise DoesNotExistError.new err.message
         else

--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'activesupport', '~> 4.0'
-  s.add_dependency 'aws-sdk', '~> 1.25'
+  s.add_dependency 'aws-sdk', '~> 2.6'
   s.add_dependency 'coderay', '~> 1.1'
   s.add_dependency 'diffy', '~> 3.0'
   s.add_dependency 'indentation', '~> 0.0'
@@ -30,5 +30,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'thor', '~> 0.18'
 
   s.add_development_dependency 'rake', '~> 10.4'
-  s.add_development_dependency 'rspec', '~> 2.99'
 end


### PR DESCRIPTION
The SDK's API changed substantially with 2.5, but the update is required to use stack change sets, which will let us show CFN's execution plan. Still need to:
- [x] Check change sets for destructive actions (there is no "safe update" option when applying change sets)
- [x] Pretty-print change set execution plans
- [ ] Any clean-up after the SDK update
