### PR TITLE
Add usePreviousValue support w/ custom YAML tag

### DIFF
--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -182,7 +182,7 @@ JSON
         if changes.empty?
           raise CannotDescribeChangeSet.new 'Empty change set' if retries == 0
           retries -= 1
-          sleep 1
+          sleep (1 * (6 - retries) * 3)
         end
       end
       changes.map do |c|

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -182,7 +182,7 @@ JSON
         if changes.empty?
           raise CannotDescribeChangeSet.new 'Empty change set' if retries == 0
           retries -= 1
-          sleep (1 * (6 - retries) * 3)
+          sleep ((6 - retries) * 3)
         end
       end
       changes.map do |c|

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -229,10 +229,17 @@ JSON
           stack_name: name,
           template_body: template.local_raw,
           parameters: parameters.resolved.map do |k, v|
-            {
-              parameter_key: k,
-              parameter_value: v
-            }
+            if v.is_a? Stacker::Stack::Parameter::UsePreviousValue
+              {
+                parameter_key: k,
+                use_previous_value: true
+              }
+            else
+              {
+                parameter_key: k,
+                parameter_value: v
+              }
+            end
           end,
           capabilities: capabilities.local,
           change_set_name: csname

--- a/lib/stacker/stack/parameter.rb
+++ b/lib/stacker/stack/parameter.rb
@@ -96,3 +96,32 @@ module Stacker
     end
   end
 end
+
+module Stacker
+  class Stack
+    class Parameter
+      class UsePreviousValue
+        def to_yaml_type
+          'UsePreviousValue'
+        end
+
+        def encode_with coder
+        end
+
+        def init_with coder
+          initialize
+        end
+
+        def to_string_representation
+          '!<UsePreviousValue>'
+        end
+
+        def self.from_string_representation
+          UsePreviousValue.new
+        end
+      end
+
+      YAML.add_tag 'UsePreviousValue', UsePreviousValue
+    end
+  end
+end


### PR DESCRIPTION
Providing `!<UsePreviousValue>` as a param value in a region file maps to CFN's `usePreviousValue` flag.

Not quite ready for merge, most of the methods in `UsePreviousValue` are copy-🍝 and can probably be removed or fixed.